### PR TITLE
Use interaction ids to search for three elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare type Scene = {
 };
 
 declare type Interaction = {
-  id?: string;
+  id: string;
   interactionpos: string;
   action: {
     library: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare type Scene = {
 };
 
 declare type Interaction = {
+  id?: string;
   interactionpos: string;
   action: {
     library: string;

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -350,10 +350,7 @@ export default class Main extends React.Component {
           this.state.currentScene
         );
 
-        updatePosition(
-          interaction,
-          event.data
-        );
+        updatePosition(interaction, event.data);
       }
       else {
         // The event was triggered by camera movement

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -10,7 +10,7 @@ import './Main.scss';
 import InteractionEditor, {InteractionEditingType} from "./EditingDialog/InteractionEditor";
 import {H5PContext} from "../context/H5PContext";
 import {deleteScene, getSceneFromId, setScenePositionFromCamera, updateScene} from "../h5phelpers/sceneParams";
-import {isGoToScene, updatePosition} from "../h5phelpers/libraryParams";
+import {getInteractionFromElement, isGoToScene, updatePosition} from "../h5phelpers/libraryParams";
 import {showConfirmationDialog} from "../h5phelpers/h5pComponents";
 import {addBehavioralListeners} from "../h5phelpers/editorForms";
 
@@ -326,26 +326,39 @@ export default class Main extends React.Component {
     });
 
     this.scenePreview.off('movestop');
-    this.scenePreview.on('movestop', e => {
-      if (!e.data) {
+
+    this.scenePreview.on('movestop', 
+      /**
+       * @param {{
+       *  data: {
+       *    target: HTMLElement;
+       *    yaw: number;
+       *    pitch: number;
+       *  }
+       * }} event
+       */
+      event => {
+      if (!event.data) {
         return;
       }
-
-      if (e.data.target) {
-        const index = this.scenePreview.threeSixty.indexOf(e.data.target);
-
-        // This is an element
-        updatePosition(
+      
+      const isElementMovement = Boolean(event.data.target);
+      if (isElementMovement) {
+        const interaction = getInteractionFromElement(
+          event.data.target, 
           this.context.params.scenes,
-          this.state.currentScene,
-          index,
-          e.data
+          this.state.currentScene
+        );
+
+        updatePosition(
+          interaction,
+          event.data
         );
       }
       else {
-        // This is the camera
+        // The event was triggered by camera movement
         this.setState({
-          currentCameraPosition: e.data.yaw + ',' + e.data.pitch,
+          currentCameraPosition: `${event.data.yaw},${event.data.pitch}`,
         });
       }
     });

--- a/src/h5phelpers/libraryParams.js
+++ b/src/h5phelpers/libraryParams.js
@@ -16,6 +16,7 @@ export const Libraries = {
  */
 export const getDefaultLibraryParams = (uberName) => {
   return {
+    id: H5P.createUUID(),
     interactionpos: '', // Filled in on saving interaction
     action: {
       library: uberName,

--- a/src/h5phelpers/libraryParams.js
+++ b/src/h5phelpers/libraryParams.js
@@ -25,18 +25,25 @@ export const getDefaultLibraryParams = (uberName) => {
 };
 
 /**
- * Updates position of interaction in parameters
- *
+ * @param {HTMLElement} element 
  * @param {Scene[]} scenes
  * @param {number} sceneId
- * @param {number} interactionIndex
+ * @returns {Interaction}
+ */
+export const getInteractionFromElement = (element, scenes, sceneId) => {
+  const interactionId = element.dataset.interactionId;
+
+  const scene = getSceneFromId(scenes, sceneId);
+  return scene.interactions.find(interaction => interaction.id === interactionId);
+}
+
+/**
+ * Updates position of interaction
+ *
+ * @param {Interaction} interaction
  * @param {CameraPosition} pos
  */
-export const updatePosition = (scenes, sceneId, interactionIndex, pos) => {
-  const scene = getSceneFromId(scenes, sceneId);
-  const interaction = scene.interactions[interactionIndex];
-
-  // Update interaction pos
+export const updatePosition = (interaction, pos) => {
   interaction.interactionpos = `${pos.yaw},${pos.pitch}`;
 };
 


### PR DESCRIPTION
We use this id for searching through three elements, instead of relying on indeces. The element's index is changed if we switch between 2d and 3d rendering, as it's deleted and re-added at the bottom of the list. Using a uuid instead is safer and more future-proof.